### PR TITLE
Quest 2 / 90Hz mode..!

### DIFF
--- a/Projects/Android/AndroidManifest.xml
+++ b/Projects/Android/AndroidManifest.xml
@@ -18,6 +18,7 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<application android:allowBackup="false" android:icon="@drawable/ic_qquest" android:label="@string/quakequest">
 		<meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
+        <meta-data android:name="com.oculus.supportedDevices" android:value="quest|delmar"/>
 		<!-- The activity is the built-in NativeActivity framework class. -->
 		<!-- launchMode is set to singleTask because there should never be multiple copies of the app running. -->
 		<!-- Theme.Black.NoTitleBar.Fullscreen gives solid black instead of a (bad stereoscopic) gradient on app transition. -->

--- a/Projects/Android/AndroidManifest.xml
+++ b/Projects/Android/AndroidManifest.xml
@@ -18,7 +18,7 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<application android:allowBackup="false" android:icon="@drawable/ic_qquest" android:label="@string/quakequest">
 		<meta-data android:name="com.samsung.android.vr.application.mode" android:value="vr_only"/>
-        <meta-data android:name="com.oculus.supportedDevices" android:value="quest|delmar"/>
+        <meta-data android:name="com.oculus.supportedDevices" android:value="quest|quest2"/>
 		<!-- The activity is the built-in NativeActivity framework class. -->
 		<!-- launchMode is set to singleTask because there should never be multiple copies of the app running. -->
 		<!-- Theme.Black.NoTitleBar.Fullscreen gives solid black instead of a (bad stereoscopic) gradient on app transition. -->

--- a/Src/QuakeQuest_SurfaceView.c
+++ b/Src/QuakeQuest_SurfaceView.c
@@ -49,6 +49,8 @@ Copyright	:	Copyright 2015 Oculus VR, LLC. All Rights reserved.
 #define SOURCE_JOYSTICK 0x01000010
 
 
+float maximumSupportedFramerate=60.0; //The lowest default framerate
+
 // EXT_texture_border_clamp
 #ifndef GL_CLAMP_TO_BORDER
 #define GL_CLAMP_TO_BORDER			0x812D
@@ -1457,6 +1459,11 @@ static void ovrApp_HandleVrModeChanges( ovrApp * app )
 			// Set performance parameters once we have entered VR mode and have a valid ovrMobile.
 			if ( app->Ovr != NULL )
 			{
+                //AmmarkoV : Set our refresh rate..!
+                ovrResult result = vrapi_SetDisplayRefreshRate(app->Ovr,maximumSupportedFramerate);
+                if (result == ovrSuccess) { ALOGV("Changed refresh rate. %f Hz",maximumSupportedFramerate); } else 
+                                          { ALOGV("Failed to change refresh rate to 90Hz Result=%d",result); }
+
 				vrapi_SetClockLevels( app->Ovr, app->CpuLevel, app->GpuLevel );
 
 				ALOGV( "		vrapi_SetClockLevels( %d, %d )", app->CpuLevel, app->GpuLevel );
@@ -2297,6 +2304,30 @@ void * AppThreadFunction( void * parm )
     //Using a symmetrical render target
     vrWidth=vrapi_GetSystemPropertyInt( &java, VRAPI_SYS_PROP_SUGGESTED_EYE_TEXTURE_WIDTH ) * SS_MULTIPLIER;
     vrHeight=vrWidth;
+
+
+
+    //AmmarkoV : Query Refresh rates and select maximum..!
+    //----------------------------------------------------------------------------------------------------------- 
+    int numberOfRefreshRates = vrapi_GetSystemPropertyInt(&java,VRAPI_SYS_PROP_NUM_SUPPORTED_DISPLAY_REFRESH_RATES);
+    float refreshRatesArray[16]; //Refresh rates are currently (12/2020) the following 4 : 60.0 / 72.0 / 80.0 / 90.0 
+    if (numberOfRefreshRates > 16 ) { numberOfRefreshRates = 16; }
+    vrapi_GetSystemPropertyFloatArray(&java, VRAPI_SYS_PROP_SUPPORTED_DISPLAY_REFRESH_RATES,&refreshRatesArray[0], numberOfRefreshRates);
+    for (int i = 0; i < numberOfRefreshRates; i++) {
+                                                     ALOGV("Supported refresh rate : %s Hz", refreshRatesArray[i]);
+                                                     if (maximumSupportedFramerate<refreshRatesArray[i])
+                                                         {
+                                                             maximumSupportedFramerate=refreshRatesArray[i];
+                                                         }
+                                                   }
+    if (maximumSupportedFramerate>90.0)
+        {
+          ALOGV("Soft limiting to 90.0 Hz as per John carmack's request ( https://www.onlinepeeps.org/oculus-quest-2-according-to-carmack-in-the-future-also-at-120-hz/ );P");
+          maximumSupportedFramerate=90.0; 
+        }
+    //----------------------------------------------------------------------------------------------------------- 
+
+
 
 
 	ovrEgl_CreateContext( &appState.Egl, NULL );


### PR DESCRIPTION
I added a minimal code segment that queries the available refresh rates of the OVR API and selects the highest with a maximum ceiling of 90Hz 

Tested it on my Quest 2 and it works fine as seen [in this video recording](http://ammar.gr/oculus/quakequest90hz.mp4) :) 

Cheers guys, thanks for your great work!
Playing Quake on the Quest 2 is awesome :D